### PR TITLE
[test] Drop Workflow Dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/catnip-tcp-ping-pong.yml
+++ b/.github/workflows/catnip-tcp-ping-pong.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/catnip-tcp-push-pop.yml
+++ b/.github/workflows/catnip-tcp-push-pop.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/catnip-udp-ping-pong.yml
+++ b/.github/workflows/catnip-udp-ping-pong.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/catnip-udp-push-pop.yml
+++ b/.github/workflows/catnip-udp-push-pop.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  workflow_dispatch:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Description
========

In this PR I drop workflow dispatch in GitHub actions, because branch filtering is no longer supported on this dispatching option.